### PR TITLE
Add traefik for reverse proxy

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,15 +1,34 @@
-version: "3.9"
-
 services:
   backend:
     build: .
-    ports:
-      - "127.0.0.1:8000:8000"
       #    depends_on:
       #      db:
       #        condition: service_healthy
     tty: true
     restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.backend.entrypoints=web"
+
+      # We'll replace this later with our own domain
+      - "traefik.http.routers.backend.rule=Host(`backend.localhost`)"
+
+  reverse-proxy:
+    image: traefik:v3.1
+    # Enables the web UI and tells Traefik to listen to docker
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entryPoints.web.address=:80"
+    ports:
+      # The HTTP port
+      - "80:80"
+      # The Web UI (enabled by --api.insecure=true)
+      - "8080:8080"
+    volumes:
+      # Scary! But should be ok for us
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
     #  db:
     #    image: mysql


### PR DESCRIPTION
Picked Traefik over nginx because it can do TLS easily.