### PR TITLE
Revert "Bump python from 3.12.6-slim-bullseye to 3.13.0-slim-bullseye in the container-dependencies group"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.0-slim-bullseye@sha256:5f806dfaaf027b52e0982a4aa0246acb902d8c8d12e0965015440099c63759a2 AS builder
+FROM python:3.12.6-slim-bullseye@sha256:6fe70237cff8ad7c0a91b992cb7cb454187dfd2e3f08ce2d023907d76db8c287 AS builder
 
 RUN pip install -U pip setuptools wheel && pip install pdm
 
@@ -8,7 +8,7 @@ RUN mkdir __pypackages__ && pdm install --prod --no-lock --no-editable
 COPY src/ src/
 RUN pdm install --prod --no-lock --no-editable
 
-FROM python:3.13.0-slim-bullseye@sha256:5f806dfaaf027b52e0982a4aa0246acb902d8c8d12e0965015440099c63759a2 AS prod
+FROM python:3.12.6-slim-bullseye@sha256:6fe70237cff8ad7c0a91b992cb7cb454187dfd2e3f08ce2d023907d76db8c287 AS prod
 
 ENV PYTHONPATH=/app/pkgs
 WORKDIR /app


### PR DESCRIPTION
Reverts Book-Recommender/backend#10. 